### PR TITLE
Add LightlyStudio to Data Labelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We do value open collaboration and knowledge sharing, so we recommend not to lim
 - [TagAnamoly](https://github.com/Microsoft/TagAnomaly) - Anomaly detection labeling tool, specifically for multiple time series (one time series per category).
 - [EchoML](https://github.com/ritazh/EchoML) - Play, visualize and annotate your audio files
 - [LabelStudio](https://github.com/heartexlabs/label-studio) - Label Studio is an open-source data labeling tool. It lets you label data types like audio, text, images, videos, and time series with a simple and straightforward UI and export to various model formats.
+- [LightlyStudio](https://github.com/lightly-ai/lightly-studio) - LightlyStudio is an open source tool for curating, annotating, and managing vision datasets (images and videos). It supports embedding-based auto-selection, annotation, and auto-labeling for bounding boxes, segmentation, and captions.
 - [Awesome Open Source Data Annotation & Labeling Tools](https://github.com/zenml-io/awesome-open-data-annotation) - A list of the open-source tools available (sorted by task type) for anyone who wants to label data. Only actively maintained tools are listed.
 
 ## 🛠️ Data Preparation


### PR DESCRIPTION
## Adding LightlyStudio

[LightlyStudio](https://github.com/lightly-ai/lightly-studio) is an **open source** tool for curating, annotating, and managing vision datasets (images and videos). Free to self-host, with an enterprise version for teams that need SSO, access control, and managed infrastructure.

**Why it fits this list:**
Covers the full annotation workflow for vision data, including bounding boxes, segmentation, and captions, plus embedding-based auto-selection to find diverse, representative samples.

**Key features:**
- Embedding-based auto-selection to find diverse, representative samples
- Annotation and auto-labeling support (bounding boxes, segmentation, captions)
- Built for vision data: images and videos
- Open source and self-hostable, with an enterprise version for teams

**Links:** [GitHub](https://github.com/lightly-ai/lightly-studio) | [Docs](https://docs.lightly.ai/studio/) | [Website](https://www.lightly.ai/lightly-studio)

![LightlyStudio demo](https://storage.googleapis.com/lightly-public/studio/embedding.gif)